### PR TITLE
Send events for multiple files

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -229,41 +229,30 @@ func (w *Watcher) Start(pollInterval time.Duration) error {
 		}
 
 		if len(fileList) > len(w.Files) {
-			// TODO: Return all new files?
-			//
 			// Check for new files.
-			var addedFile os.FileInfo
 			for path, fInfo := range fileList {
 				if _, found := w.Files[path]; !found {
-					addedFile = fInfo
+					w.Event <- Event{EventType: EventFileAdded, FileInfo: fInfo}
 				}
 			}
-			w.Event <- Event{EventType: EventFileAdded, FileInfo: addedFile}
 			w.Files = fileList
 		} else if len(fileList) < len(w.Files) {
-			// TODO: Return all deleted files?
-			//
 			// Check for deleted files.
-			var deletedFile os.FileInfo
 			for path, fInfo := range w.Files {
 				if _, found := fileList[path]; !found {
-					deletedFile = fInfo
+					w.Event <- Event{EventType: EventFileDeleted, FileInfo: fInfo}
 				}
 			}
-			w.Event <- Event{EventType: EventFileDeleted, FileInfo: deletedFile}
 			w.Files = fileList
 		}
 
-		// TODO: Return all modified files?
-		//
 		// Check for modified files.
 		for i, file := range w.Files {
 			if fileList[i].ModTime() != file.ModTime() {
 				w.Event <- Event{EventType: EventFileModified, FileInfo: file}
-				w.Files = fileList
-				break
 			}
 		}
+		w.Files = fileList
 
 		// Sleep for a little bit.
 		time.Sleep(pollInterval)

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -24,6 +24,15 @@ func setup(t *testing.T) (string, func()) {
 		t.Error(err)
 	}
 
+	files := []string{"file_1.txt", "file_2.txt", "file_3.txt"}
+
+	for _, f := range files {
+		filePath := filepath.Join(testDir, f)
+		if err := ioutil.WriteFile(filePath, []byte{}, 0755); err != nil {
+			t.Error(err)
+		}
+	}
+
 	err = ioutil.WriteFile(filepath.Join(testDir, ".dotfile"),
 		[]byte{}, 0755)
 	if err != nil {
@@ -59,8 +68,8 @@ func TestSetNonRecursive(t *testing.T) {
 		t.Error(err)
 	}
 
-	if len(w.Files) != 4 {
-		t.Errorf("expected len(w.Files) to be 4, got %d", len(w.Files))
+	if len(w.Files) != 7 {
+		t.Errorf("expected len(w.Files) to be 7, got %d", len(w.Files))
 	}
 
 	// Make sure w.Names[0] is now equal to testDir.
@@ -124,8 +133,8 @@ func TestSetIgnoreDotFiles(t *testing.T) {
 		t.Error(err)
 	}
 
-	if len(w.Files) != 4 {
-		t.Errorf("expected len(w.Files) to be 4, got %d", len(w.Files))
+	if len(w.Files) != 7 {
+		t.Errorf("expected len(w.Files) to be 7, got %d", len(w.Files))
 	}
 
 	// Make sure w.Names[0] is now equal to testDir.
@@ -183,8 +192,8 @@ func TestSetIgnoreDotFilesAndNonRecursive(t *testing.T) {
 		t.Error(err)
 	}
 
-	if len(w.Files) != 3 {
-		t.Errorf("expected len(w.Files) to be 3, got %d", len(w.Files))
+	if len(w.Files) != 6 {
+		t.Errorf("expected len(w.Files) to be 6, got %d", len(w.Files))
 	}
 
 	// Make sure w.Names[0] is now equal to testDir.
@@ -243,7 +252,7 @@ func TestWatcherAdd(t *testing.T) {
 	}
 
 	// Make sure len(w.Files) is 5.
-	if len(w.Files) != 5 {
+	if len(w.Files) != 8 {
 		t.Errorf("expected 5 files, found %d", len(w.Files))
 	}
 
@@ -295,7 +304,7 @@ func TestWatcherRemove(t *testing.T) {
 	}
 
 	// Make sure len(w.Files) is 5.
-	if len(w.Files) != 5 {
+	if len(w.Files) != 8 {
 		t.Errorf("expected 5 files, found %d", len(w.Files))
 	}
 
@@ -380,30 +389,46 @@ func TestEventAddFile(t *testing.T) {
 		t.Error(err)
 	}
 
-	newFileName := filepath.Join(testDir, "newfile.txt")
-	err := ioutil.WriteFile(newFileName, []byte{}, 0755)
-	if err != nil {
-		t.Error(err)
+	files := map[string]bool{
+		"newfile_1.txt": false,
+		"newfile_2.txt": false,
+		"newfile_3.txt": false,
+	}
+
+	for f := range files {
+		filePath := filepath.Join(testDir, f)
+		if err := ioutil.WriteFile(filePath, []byte{}, 0755); err != nil {
+			t.Error(err)
+		}
 	}
 
 	var wg sync.WaitGroup
 	wg.Add(1)
 
 	go func() {
-		select {
-		case event := <-w.Event:
-			if event.EventType != EventFileAdded {
-				t.Errorf("expected event to be EventFileAdded, got %s",
-					event.EventType)
+		events := 0
+		for {
+			select {
+			case event := <-w.Event:
+				if event.EventType != EventFileAdded {
+					t.Errorf("expected event to be EventFileAdded, got %s",
+						event.EventType)
+				}
+
+				files[event.Name()] = true
+				events++
+
+				if events == len(files) {
+					wg.Done()
+				}
+			case <-time.After(time.Millisecond * 250):
+				for f, e := range files {
+					if !e {
+						t.Errorf("received no event for file %s", f)
+					}
+				}
+				wg.Done()
 			}
-			if event.Name() != "newfile.txt" {
-				t.Errorf("expected event file name to be newfile.txt, got %s",
-					event.Name())
-			}
-			wg.Done()
-		case <-time.After(time.Millisecond * 250):
-			t.Error("received no event from Event channel")
-			wg.Done()
 		}
 	}()
 
@@ -428,20 +453,46 @@ func TestEventDeleteFile(t *testing.T) {
 		t.Error(err)
 	}
 
-	if err := os.Remove(filepath.Join(testDir, "file.txt")); err != nil {
-		t.Error(err)
+	files := map[string]bool{
+		"file_1.txt": false,
+		"file_2.txt": false,
+		"file_3.txt": false,
+	}
+
+	for f := range files {
+		filePath := filepath.Join(testDir, f)
+		if err := os.Remove(filePath); err != nil {
+			t.Error(err)
+		}
 	}
 
 	var wg sync.WaitGroup
 	wg.Add(1)
 
 	go func() {
-		select {
-		case <-w.Event:
-			wg.Done()
-		case <-time.After(time.Millisecond * 250):
-			t.Error("received no event from Event channel")
-			wg.Done()
+		events := 0
+		for {
+			select {
+			case event := <-w.Event:
+				if event.EventType != EventFileDeleted {
+					t.Errorf("expected event to be EventEventFileDeleted, got %s",
+						event.EventType)
+				}
+
+				files[event.Name()] = true
+				events++
+
+				if events == len(files) {
+					wg.Done()
+				}
+			case <-time.After(time.Millisecond * 250):
+				for f, e := range files {
+					if !e {
+						t.Errorf("received no event for file %s", f)
+					}
+				}
+				wg.Done()
+			}
 		}
 	}()
 


### PR DESCRIPTION
If multiple files were changed (added/deleted) within one polling interval, send events for all of them, instead of just the first.