### PR TITLE
#11Implemented Wait function

### DIFF
--- a/example/basics/main.go
+++ b/example/basics/main.go
@@ -68,9 +68,9 @@ func main() {
 
 	fmt.Println()
 
-	// Trigger 2 events after 100 milliseconds.
+	// Trigger 2 events after watcher started
 	go func() {
-		time.Sleep(time.Millisecond * 100)
+		w.Wait()
 		w.TriggerEvent(watcher.Create, nil)
 		w.TriggerEvent(watcher.Remove, nil)
 	}()

--- a/example/close_watcher/main.go
+++ b/example/close_watcher/main.go
@@ -71,9 +71,9 @@ func main() {
 
 	fmt.Println()
 
-	// Close the watcher after 250 milliseconds.
+	// Close the watcher after watcher started
 	go func() {
-		time.Sleep(time.Millisecond * 250)
+		w.Wait()
 		if err := w.Close(); err != nil {
 			log.Fatalln(err)
 		}

--- a/example/ignore_files/main.go
+++ b/example/ignore_files/main.go
@@ -47,7 +47,7 @@ func main() {
 	fmt.Println()
 
 	go func() {
-		time.Sleep(time.Second * 3)
+		w.Wait()
 		// Ignore ../test_folder/test_folder_recursive and ../test_folder/.dotfile
 		if err := w.Ignore("../test_folder/test_folder_recursive", "../test_folder/.dotfile"); err != nil {
 			log.Fatalln(err)

--- a/watcher.go
+++ b/watcher.go
@@ -264,7 +264,9 @@ func (w *Watcher) Remove(name string) (err error) {
 
 // TriggerEvent is a method that can be used to trigger an event, separate to
 // the file watching process.
+// This function mandatory wait when the watcher started
 func (w *Watcher) TriggerEvent(eventType Op, file os.FileInfo) {
+	w.Wait()
 	if file == nil {
 		file = &fileInfo{name: "triggered event", modTime: time.Now()}
 	}

--- a/watcher.go
+++ b/watcher.go
@@ -93,6 +93,7 @@ type Watcher struct {
 	options []Option
 
 	mu        *sync.Mutex
+	wg        *sync.WaitGroup
 	running   bool
 	files     map[string]os.FileInfo
 	ignored   map[string]struct{}
@@ -101,12 +102,16 @@ type Watcher struct {
 }
 
 // New returns a new initialized *Watcher.
+// and set a block for gorutines which shouldn't be started before watcher
 func New(options ...Option) *Watcher {
+	wg := new(sync.WaitGroup)
+	wg.Add(1)
 	return &Watcher{
 		Event:   make(chan Event),
 		Error:   make(chan error),
 		options: options,
 		mu:      new(sync.Mutex),
+		wg:      wg,
 		files:   make(map[string]os.FileInfo),
 		ignored: make(map[string]struct{}),
 		names:   []string{},
@@ -290,6 +295,11 @@ func (w *Watcher) Close() error {
 	return nil
 }
 
+// Wait blocks until the watcher started.
+func (w *Watcher) Wait() {
+	w.wg.Wait()
+}
+
 // Start starts the watching process and checks for changes every `pollInterval` duration.
 // If pollInterval is 0, the default is 100ms.
 func (w *Watcher) Start(pollInterval time.Duration) error {
@@ -304,6 +314,8 @@ func (w *Watcher) Start(pollInterval time.Duration) error {
 	w.mu.Lock()
 	w.running = true
 	w.mu.Unlock()
+
+	w.wg.Done()
 
 	for {
 		w.mu.Lock()


### PR DESCRIPTION
Implemented Wait function. Check issue #11 
This problem was before but it was hidden by _time.Sleep_
<https://github.com/radovskyb/watcher/blob/27b48fd63be1e672008140b9f99ae2a9dd3888fe/example/basics/main.go#L73>
There are problem with _TriggerEvent_ . This function doesn't emulate os events. This function just change state of watcher. It's wrong! 
When I used examples and I was trying  _TriggerEvent_  before _Start_ it's always was success.
This function can be useful but definitely not for test  
And definitely should have _w.Wait_  inside
**update**
I just added _w.Wait_  inside _TriggerEvent_