### PR TITLE
[hotfix/fix-test-fatal] Fatal can't take formatting argument, fatalf can

### DIFF
--- a/watcher_test.go
+++ b/watcher_test.go
@@ -104,22 +104,22 @@ func TestFileInfo(t *testing.T) {
 
 	// Test file info methods.
 	if fInfo.Name() != "finfo" {
-		t.Fatal("expected fInfo.Name() to be 'finfo', got %s", fInfo.Name())
+		t.Fatalf("expected fInfo.Name() to be 'finfo', got %s", fInfo.Name())
 	}
 	if fInfo.IsDir() != true {
-		t.Fatal("expected fInfo.IsDir() to be true, got %t", fInfo.IsDir())
+		t.Fatalf("expected fInfo.IsDir() to be true, got %t", fInfo.IsDir())
 	}
 	if fInfo.Size() != 1 {
-		t.Fatal("expected fInfo.Size() to be 1, got %d", fInfo.Size())
+		t.Fatalf("expected fInfo.Size() to be 1, got %d", fInfo.Size())
 	}
 	if fInfo.Sys() != nil {
-		t.Fatal("expected fInfo.Sys() to be nil, got %v", fInfo.Sys())
+		t.Fatalf("expected fInfo.Sys() to be nil, got %v", fInfo.Sys())
 	}
 	if fInfo.ModTime() != modTime {
-		t.Fatal("expected fInfo.ModTime() to be %v, got %v", modTime, fInfo.ModTime())
+		t.Fatalf("expected fInfo.ModTime() to be %v, got %v", modTime, fInfo.ModTime())
 	}
 	if fInfo.Mode() != os.ModeDir {
-		t.Fatal("expected fInfo.Mode() to be os.ModeDir, got %#v", fInfo.Mode())
+		t.Fatalf("expected fInfo.Mode() to be os.ModeDir, got %#v", fInfo.Mode())
 	}
 
 	w := New()


### PR DESCRIPTION
Fatal method doesn't work with a formatting parameter with the last versions of Go.