### PR TITLE
fixed removing parent path when encountering an error

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -497,7 +497,7 @@ func (w *Watcher) retrieveFileList() map[string]os.FileInfo {
 				if os.IsNotExist(err) {
 					w.Error <- ErrWatchedFileDeleted
 					w.mu.Unlock()
-					w.RemoveRecursive(name)
+					w.RemoveRecursive(err.(*os.PathError).Path)
 					w.mu.Lock()
 				} else {
 					w.Error <- err
@@ -509,7 +509,7 @@ func (w *Watcher) retrieveFileList() map[string]os.FileInfo {
 				if os.IsNotExist(err) {
 					w.Error <- ErrWatchedFileDeleted
 					w.mu.Unlock()
-					w.Remove(name)
+					w.Remove(err.(*os.PathError).Path)
 					w.mu.Lock()
 				} else {
 					w.Error <- err


### PR DESCRIPTION
When an ErrWatchedFileDeleted was sent, the current behavior was to remove the parent directory from the watchlist instead of just the erroneous file. This PR intends to fix this.

See https://github.com/radovskyb/watcher/issues/48 for more info.