### PR TITLE
Regex exclude files

### DIFF
--- a/example/regex/main.go
+++ b/example/regex/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"time"
+
+	"github.com/radovskyb/watcher"
+)
+
+func main() {
+	w := watcher.New()
+
+	// Ignore files that have a certain pattern
+	r := regexp.MustCompile("node_modules")
+	w.AddFilterHook(watcher.RegexIgnoreHook(r, true))
+
+	go func() {
+		for {
+			select {
+			case event := <-w.Event:
+				fmt.Println(event) // Print the event's info.
+			case err := <-w.Error:
+				log.Fatalln(err)
+			case <-w.Closed:
+				return
+			}
+		}
+	}()
+
+	// Watch test_folder recursively for changes.
+	if err := w.AddRecursive("../test_folder"); err != nil {
+		log.Fatalln(err)
+	}
+
+	// Start the watching process - it'll check for changes every 100ms.
+	if err := w.Start(time.Millisecond * 100); err != nil {
+		log.Fatalln(err)
+	}
+}

--- a/watcher.go
+++ b/watcher.go
@@ -92,7 +92,7 @@ type FilterFileHookFunc func(info os.FileInfo, fullPath string) error
 // RegexFilterHook is a function that accepts or rejects a file
 // for listing based on whether it's filename or full path matches
 // a regular expression.
-func RegexFilterHook(r *regexp.Regexp, useFullPath bool) FilterFileHookFunc {
+func regexFilterHookFN(r *regexp.Regexp, useFullPath bool, reverse bool) FilterFileHookFunc {
 	return func(info os.FileInfo, fullPath string) error {
 		str := info.Name()
 
@@ -101,13 +101,25 @@ func RegexFilterHook(r *regexp.Regexp, useFullPath bool) FilterFileHookFunc {
 		}
 
 		// Match
-		if r.MatchString(str) {
+		matched := r.MatchString(str)
+		if reverse {
+			matched = !matched
+		}
+		if matched {
 			return nil
 		}
 
 		// No match.
 		return ErrSkip
 	}
+}
+
+func RegexFilterHook(r *regexp.Regexp, useFullPath bool) FilterFileHookFunc {
+	return regexFilterHookFN(r, useFullPath, false)
+}
+
+func RegexIgnoreHook(r *regexp.Regexp, useFullPath bool) FilterFileHookFunc {
+	return regexFilterHookFN(r, useFullPath, true)
 }
 
 // Watcher describes a process that watches files for changes.


### PR DESCRIPTION
New `RegexIgnoreHook` method for excluding files with regex syntax, to prevent files from firing an event. Same syntax as `RegexFilterHook`

###### Example
```go
// Ignore files that have a certain pattern
r := regexp.MustCompile("node_modules")
w.AddFilterHook(watcher.RegexIgnoreHook(r, true))
```