### PR TITLE
Fix wrong variable scope in tests

### DIFF
--- a/watcher_test.go
+++ b/watcher_test.go
@@ -58,7 +58,7 @@ func setup(t testing.TB) (string, func()) {
 		t.Fatal(err)
 	}
 	return abs, func() {
-		if os.RemoveAll(testDir); err != nil {
+		if err = os.RemoveAll(testDir); err != nil {
 			t.Fatal(err)
 		}
 	}


### PR DESCRIPTION
The `err` used in the cleaning function was reporting error about the absolute path fails. It now reports fails to remove folder