### PR TITLE
Fix filtering on root folder and add filtering tests

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -233,6 +233,16 @@ func (w *Watcher) list(name string) (map[string]os.FileInfo, error) {
 	}
 
 	fileList[name] = stat
+	for _, f := range w.ffh {
+		err := f(stat, name)
+		if err == ErrSkip {
+			delete(fileList, name)
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	// If it's not a directory, just return.
 	if !stat.IsDir() {


### PR DESCRIPTION
The filtering was only applied to the element inside the watched path, but it was not applied to the watched path himself.
I've added a test to prevent regression and i've also added some more test about filtering.