### PR TITLE
Fix a bug on windows when isHiddenFile returns an error

### DIFF
--- a/ishidden_windows.go
+++ b/ishidden_windows.go
@@ -3,17 +3,32 @@
 package watcher
 
 import (
+	"os"
 	"syscall"
 )
 
 func isHiddenFile(path string) (bool, error) {
 	pointer, err := syscall.UTF16PtrFromString(path)
 	if err != nil {
+		if os.IsNotExist(err) {
+			err = &os.PathError{
+				Op:   "isHidden",
+				Path: path,
+				Err:  err,
+			}
+		}
 		return false, err
 	}
 
 	attributes, err := syscall.GetFileAttributes(pointer)
 	if err != nil {
+		if os.IsNotExist(err) {
+			err = &os.PathError{
+				Op:   "isHidden",
+				Path: path,
+				Err:  err,
+			}
+		}
 		return false, err
 	}
 

--- a/ishidden_windows_test.go
+++ b/ishidden_windows_test.go
@@ -1,0 +1,19 @@
+// +build windows
+
+package watcher
+
+import (
+	"os"
+	"testing"
+)
+
+func TestIsHiddenFileReturnsPathError(t *testing.T) {
+	_, err := isHiddenFile("./qqdkqdsdmlqdsd.nop")
+	if err == nil {
+		t.Fatal("isHidden should have returned an error")
+	}
+
+	if _, ok := err.(*os.PathError); !ok {
+		t.Fatal("Error is not a PathError")
+	}
+}


### PR DESCRIPTION
On windows when the `isHiddenFile()` methods returns an error it is of type `os.Errno`.

At another location on the code there is this particular piece of code:

```
list, err = w.list(name)
if err != nil {
	if os.IsNotExist(err) {
		w.mu.Unlock()
		if name == err.(*os.PathError).Path {
			w.Error <- ErrWatchedFileDeleted
			w.Remove(name)
		}
		w.mu.Lock()
	} else {
		w.Error <- err
	}
}
```

where `list()` uses isHiddenFile.

The problem is that `os.IsNotExist(err)` returns true for `os.Errno` but fails to cast to `os.PathError` which results in weird lock state because of the panic.