### PR TITLE
added ScanNow()

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -22,6 +22,11 @@ var (
 	// from previously calling Start and not yet calling Close.
 	ErrWatcherRunning = errors.New("error: watcher is already running")
 
+	// ErrWatcherNotRunning occurs when trying to perform a ScanNow
+	// when the watcher is not running. It will also occur if Close is called
+	// whilst a ScanNow() is running / pending.
+	ErrWatcherNotRunning = errors.New("error: watcher is not running")
+
 	// ErrWatchedFileDeleted is an error that occurs when a file or folder that was
 	// being watched has been deleted.
 	ErrWatchedFileDeleted = errors.New("error: watched file or folder deleted")
@@ -129,6 +134,7 @@ type Watcher struct {
 	ops          map[Op]struct{}        // Op filtering.
 	ignoreHidden bool                   // ignore hidden files or not.
 	maxEvents    int                    // max sent events per cycle
+	scanNow      chan chan struct{}     // allows requests for immediate synchronous scans
 }
 
 // New creates a new Watcher.
@@ -147,6 +153,7 @@ func New() *Watcher {
 		files:   make(map[string]os.FileInfo),
 		ignored: make(map[string]struct{}),
 		names:   make(map[string]bool),
+		scanNow: make(chan chan struct{}),
 	}
 }
 
@@ -550,6 +557,8 @@ func (w *Watcher) Start(d time.Duration) error {
 	// Unblock w.Wait().
 	w.wg.Done()
 
+	var scanNowRequest chan struct{}
+
 	for {
 		// done lets the inner polling cycle loop know when the
 		// current cycle's method has finished executing.
@@ -589,7 +598,7 @@ func (w *Watcher) Start(d time.Duration) error {
 					}
 				}
 				numEvents++
-				if w.maxEvents > 0 && numEvents > w.maxEvents {
+				if scanNowRequest == nil && w.maxEvents > 0 && numEvents > w.maxEvents {
 					close(cancel)
 					break inner
 				}
@@ -604,8 +613,52 @@ func (w *Watcher) Start(d time.Duration) error {
 		w.files = fileList
 		w.mu.Unlock()
 
+		if scanNowRequest != nil {
+			close(scanNowRequest)
+			scanNowRequest = nil
+		}
+
 		// Sleep and then continue to the next loop iteration.
-		time.Sleep(d)
+		// If a request to do a full scan is received, handle it and then signal to the requester it is complete.
+		select {
+		case <-w.close: // break out of wait early if we get a Close
+		case scanNowRequest = <-w.scanNow: // sync scan request received
+		case <-time.After(d): // periodic re-roll time elapsed
+		}
+	}
+}
+
+// ScanNow can be called on a already running watcher to perform an immediate synchronous scan of all watched files
+// and generate the events for any changes. When ScanNow() returns to the caller, all events for any changed files
+// have been published. ScanNow() can be used when you know FS changes have occurred and you want to ensure all events
+// for the changes have been gathered before continuing, for example, to better process batched updates to groups of
+// files.
+// You can also specify a very long poll duration and then use ScanNow() to break from the poll wait and perform a scan
+// before going back to sleep.
+func (w *Watcher) ScanNow() error {
+	w.mu.Lock()
+	if !w.running {
+		w.mu.Unlock()
+		return ErrWatcherNotRunning
+	}
+	w.mu.Unlock()
+
+	scanComplete := make(chan struct{})
+	select {
+	case w.scanNow <- scanComplete:
+	case <-w.close:
+		// if the watcher is no longer running, or is closed whilst we're waiting for our scan to be accepted, return
+		// an error
+		return ErrWatcherNotRunning
+	}
+
+	select {
+	case <-w.close:
+		// if the watcher is closed whilst we're waiting for our scan to complete, return an error
+		return ErrWatcherNotRunning
+	case <-scanComplete:
+		// scan completed ok
+		return nil
 	}
 }
 
@@ -700,6 +753,7 @@ func (w *Watcher) Wait() {
 }
 
 // Close stops a Watcher and unlocks its mutex, then sends a close signal.
+// Note, it is not safe to Start() a Watcher again after closing it. You must create a new Watcher.
 func (w *Watcher) Close() {
 	w.mu.Lock()
 	if !w.running {
@@ -711,5 +765,6 @@ func (w *Watcher) Close() {
 	w.names = make(map[string]bool)
 	w.mu.Unlock()
 	// Send a close signal to the Start method.
-	w.close <- struct{}{}
+	// Use a channel close() rather than a channel write, so that ScanNow() can react to the closure also.
+	close(w.close)
 }


### PR DESCRIPTION
ScanNow() causes the file watch loop to run once, and ensures all events have been posted before returning. It blocks until the loop has ran through to completion once. It allows the caller to "synchronize" with the file system state, so is useful for batch updating after it is known / suspected file events have probably occurred.

Example use:
When an application triggers a bunch of changes to watched files itself, it knows there will be some watcher events in the future, and may want to wait until they've all occurred before continuing, rather than having them occur at some unknown point in the future (depending on the poll interval). It can make the changes, call `ScanNow()` and know when it returns that all watcher events from its changes have been received.