### PR TITLE
skip ignored files before callbacks

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -308,16 +308,6 @@ func (w *Watcher) listRecursive(name string) (map[string]os.FileInfo, error) {
 			return err
 		}
 
-		for _, f := range w.ffh {
-			err := f(info, path)
-			if err == ErrSkip {
-				return nil
-			}
-			if err != nil {
-				return err
-			}
-		}
-
 		// If path is ignored and it's a directory, skip the directory. If it's
 		// ignored and it's a single file, skip the file.
 		_, ignored := w.ignored[path]
@@ -333,6 +323,17 @@ func (w *Watcher) listRecursive(name string) (map[string]os.FileInfo, error) {
 			}
 			return nil
 		}
+
+		for _, f := range w.ffh {
+			err := f(info, path)
+			if err == ErrSkip {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+		}
+
 		// Add the path and it's info to the file list.
 		fileList[path] = info
 		return nil


### PR DESCRIPTION
This updates `listRecursive()` to check the ignored or hidden status of a file path before calling the filter hooks. This can have massive CPU savings if the watcher ignores a massive sub directory in a recursively-watched directory. 

It's also consistent with `list()`:

https://github.com/radovskyb/watcher/blob/f5989f8deca223d590d5a130c77ea375fe9fde30/watcher.go#L260-L272