### PR TITLE
support for afero.Fs filesystem abstraction

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -199,10 +199,7 @@ func (w *Watcher) Add(name string) (err error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	name, err = filepath.Abs(name)
-	if err != nil {
-		return err
-	}
+	name = filepath.Clean(name)
 
 	// If name is on the ignored list or if hidden files are
 	// ignored and name is a hidden file or directory, simply return.
@@ -290,10 +287,7 @@ func (w *Watcher) AddRecursive(name string) (err error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	name, err = filepath.Abs(name)
-	if err != nil {
-		return err
-	}
+	name = filepath.Clean(name)
 
 	fileList, err := w.listRecursive(name)
 	if err != nil {
@@ -353,10 +347,7 @@ func (w *Watcher) Remove(name string) (err error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	name, err = filepath.Abs(name)
-	if err != nil {
-		return err
-	}
+	name = filepath.Clean(name)
 
 	// Remove the name from w's names list.
 	delete(w.names, name)
@@ -389,10 +380,7 @@ func (w *Watcher) RemoveRecursive(name string) (err error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	name, err = filepath.Abs(name)
-	if err != nil {
-		return err
-	}
+	name = filepath.Clean(name)
 
 	// Remove the name from w's names list.
 	delete(w.names, name)
@@ -422,10 +410,7 @@ func (w *Watcher) RemoveRecursive(name string) (err error) {
 // For files that are already added, Ignore removes them.
 func (w *Watcher) Ignore(paths ...string) (err error) {
 	for _, path := range paths {
-		path, err = filepath.Abs(path)
-		if err != nil {
-			return err
-		}
+		path = filepath.Clean(path)
 		// Remove any of the paths that were already added.
 		if err := w.RemoveRecursive(path); err != nil {
 			return err


### PR DESCRIPTION
using this library alongside code that uses afero has been very difficult, so I decided to just add support. it adds a dependency (afero), but now you can using this against various afero filesystem implementations. by default, it uses `afero.OsFs` so it behaves the same other than one thing: `filesystem.Abs` has been changed to just `filesystem.Clean` because there is no concept of working directory when working with abstraction filesystems. 

i don't know whether to vendor this change and keep it to myself or if the added dependency and slight change in behavior is worth merging. but the option is here if nothing else as a reference for others needing to do the same.

[recreating to live on a non-master branch in my fork]