### PR TITLE
To avoid turning off the listener and restarting the listening service, you need to re-create the object.

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -709,6 +709,7 @@ func (w *Watcher) Close() {
 	w.running = false
 	w.files = make(map[string]os.FileInfo)
 	w.names = make(map[string]bool)
+	w.wg.Add(1)
 	w.mu.Unlock()
 	// Send a close signal to the Start method.
 	w.close <- struct{}{}


### PR DESCRIPTION
…e, you need to re-create the object

Turning on the listening service again after closing the listening service with the same object will panic because the close method does not re-add the wait list.