### PR TITLE
Fix "move" file reporting as a create event

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # watcher
 
-[![Build Status](https://travis-ci.org/radovskyb/watcher.svg?branch=master)](https://travis-ci.org/radovskyb/watcher)
-
 `watcher` is a Go package for watching for files or directory changes (recursively or non recursively) without using filesystem events, which allows it to work cross platform consistently.
 
 `watcher` watches for changes and notifies over channels either anytime an event or an error has occurred.
@@ -24,7 +22,7 @@ Events contain the `os.FileInfo` of the file or directory that the event is base
 # Installation
 
 ```shell
-go get -u github.com/radovskyb/watcher/...
+go get -u github.com/airplanedev/watcher/...
 ```
 
 # Features
@@ -55,7 +53,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/radovskyb/watcher"
+	"github.com/airplanedev/watcher"
 )
 
 func main() {

--- a/cmd/watcher/README.md
+++ b/cmd/watcher/README.md
@@ -3,7 +3,7 @@
 # Installation
 
 ```shell
-go get -u github.com/radovskyb/watcher/...
+go get -u github.com/airplanedev/watcher/...
 ```
 
 # Usage

--- a/cmd/watcher/main.go
+++ b/cmd/watcher/main.go
@@ -11,7 +11,7 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/radovskyb/watcher"
+	"github.com/airplanedev/watcher"
 )
 
 func main() {

--- a/example/basics/main.go
+++ b/example/basics/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/radovskyb/watcher"
+	"github.com/airplanedev/watcher"
 )
 
 func main() {

--- a/example/close_watcher/main.go
+++ b/example/close_watcher/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/radovskyb/watcher"
+	"github.com/airplanedev/watcher"
 )
 
 func main() {

--- a/example/filter_events/main.go
+++ b/example/filter_events/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/radovskyb/watcher"
+	"github.com/airplanedev/watcher"
 )
 
 func main() {

--- a/example/ignore_files/main.go
+++ b/example/ignore_files/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/radovskyb/watcher"
+	"github.com/airplanedev/watcher"
 )
 
 func main() {

--- a/example/ignore_hidden_files/main.go
+++ b/example/ignore_hidden_files/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/radovskyb/watcher"
+	"github.com/airplanedev/watcher"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/airplanedev/watcher
+
+go 1.20

--- a/watcher.go
+++ b/watcher.go
@@ -311,6 +311,9 @@ func (w *Watcher) listRecursive(name string) (map[string]os.FileInfo, error) {
 		for _, f := range w.ffh {
 			err := f(info, path)
 			if err == ErrSkip {
+				if info.IsDir() {
+					return filepath.SkipDir
+				}
 				return nil
 			}
 			if err != nil {

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -485,7 +485,7 @@ func TestListFiles(t *testing.T) {
 	w := New()
 	w.AddRecursive(testDir)
 
-	fileList := w.retrieveFileList()
+	_, fileList := w.retrieveFileList()
 	if fileList == nil {
 		t.Error("expected file list to not be empty")
 	}
@@ -895,7 +895,7 @@ func BenchmarkListFiles(b *testing.B) {
 	}
 
 	for i := 0; i < b.N; i++ {
-		fileList := w.retrieveFileList()
+		_, fileList := w.retrieveFileList()
 		if fileList == nil {
 			b.Fatal("expected file list to not be empty")
 		}
@@ -914,7 +914,7 @@ func TestClose(t *testing.T) {
 	}
 
 	wf := w.WatchedFiles()
-	fileList := w.retrieveFileList()
+	_, fileList := w.retrieveFileList()
 
 	if len(wf) != len(fileList) {
 		t.Fatalf("expected len of wf to be %d, got %d", len(fileList), len(wf))
@@ -924,7 +924,7 @@ func TestClose(t *testing.T) {
 	w.Close()
 
 	wf = w.WatchedFiles()
-	fileList = w.retrieveFileList()
+	_, fileList = w.retrieveFileList()
 
 	// Close will be a no-op so there will still be len(fileList) files.
 	if len(wf) != len(fileList) {
@@ -963,7 +963,7 @@ func TestWatchedFiles(t *testing.T) {
 	}
 
 	wf := w.WatchedFiles()
-	fileList := w.retrieveFileList()
+	_, fileList := w.retrieveFileList()
 
 	if len(wf) != len(fileList) {
 		t.Fatalf("expected len of wf to be %d, got %d", len(fileList), len(wf))


### PR DESCRIPTION
This fixes a bug where the very first time a watched file is moved, it sends a "create" event instead of a "moved" event.

This is because:
- `w.retrieveFileList()` is called to get a list of "new files".  If it sees a file get deleted because the value of `w.names` doesn't exist anymore, it calls `w.Remove(name)` which deletes that file from the w.files list. 
- Then, in  `w.pollEvents(fileList, evt, cancel)` is given the new files and compares it to w.files - if something is in w.files (the old list) but is not in newFiles, it's considered a "moved" event. Otherwise anything just in the newFiles but not in w.files is "created".
-- since retrieveFileList already called w.Remove and took the deleted file out of `w.files`, w.files is actually shorter than what’s returned by retrieveFileList- so it thinks it's a create.

I think this doesn't happen on subsequent file moves because that file isn't added back to the list, so it's not registered as a `ErrWatchedFileDeleted` event the second time since it's no longer in the list of w.names even though w.files is accurate.